### PR TITLE
Implement per-metric schema

### DIFF
--- a/utils/mock_data.py
+++ b/utils/mock_data.py
@@ -122,7 +122,7 @@ POINTS = {
                     ["Poland", "Germany", "Czech", "Austria"],
                 ),
                 itertools.count(),
-                (n **2 % 10 / 20 for n in itertools.count()),
+                (n ** 2 % 10 / 20 for n in itertools.count()),
             )
         )
     ),

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -69,7 +69,10 @@ def wait_until_responds(url: str, max_seconds: int = 10):
 def running_server(compiled_server, redis):
     """ Provides a test server + Redis pair. """
     with Popen(
-        [f"{SERVER_ROOT}/target/debug/kpyay-server", redis], stdout=PIPE, stderr=PIPE
+        [f"{SERVER_ROOT}/target/debug/kpyay-server", redis],
+        stdout=PIPE,
+        stderr=PIPE,
+        env={"RUST_LOG": "actix_web=debug"},
     ) as server_process:
         # TODO: allow port customization
         url = "http://127.0.0.1:8088"
@@ -311,7 +314,7 @@ def test_posting_corruputed_view(running_server):
 @pytest.mark.parametrize(
     "p2",
     [
-        Point(value=0.75, params={}, timestamp=None, version=None,),  # missing param
+        Point(value=0.75, params={}, timestamp=None, version=None),  # missing param
         Point(  # redundant param
             value=0.75,
             params={"lang": "suahili", "dialect": "something"},
@@ -330,7 +333,7 @@ def test_posting_corruputed_view(running_server):
     ],
 )
 def test_posting_points_with_different_schema(
-    client_to_existing_content: ServerClient, p2: Point
+    client_to_existing_content: ServerClient, p2: Point,
 ):
     p1 = Point(value=0.75, params={"lang": "suahili"}, timestamp=None, version=None,)
 

--- a/utils/tests.py
+++ b/utils/tests.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone, timedelta
 from subprocess import PIPE, Popen
 from testing.redis import RedisServer
 
-from api import ServerClient, Point, ChartConfig
+from api import ServerClient, Point, ChartConfig, KPYayError
 
 """
 This is an integration test suite. 
@@ -306,3 +306,36 @@ def test_posting_corruputed_view(running_server):
         )._asdict(),
     )
     assert response.status_code == 400, f"Response text:\n '''{response.text}'''"
+
+
+@pytest.mark.parametrize(
+    "p2",
+    [
+        Point(value=0.75, params={}, timestamp=None, version=None,),  # missing param
+        Point(  # redundant param
+            value=0.75,
+            params={"lang": "suahili", "dialect": "something"},
+            timestamp=datetime.fromisoformat("2020-04-29T12:06:23"),
+            version=None,
+        ),
+        Point(  # once timestamp is omitted, it must always be omitted
+            value=0.75,
+            params={"lang": "suahili"},
+            timestamp=datetime.fromisoformat("2020-04-29T12:06:23"),
+            version=None,
+        ),
+        Point(  # once version is omitted, it must always be omitted
+            value=0.75, params={"lang": "suahili"}, timestamp=None, version=(1, 2, 3),
+        ),
+    ],
+)
+def test_posting_points_with_different_schema(
+    client_to_existing_content: ServerClient, p2: Point
+):
+    p1 = Point(value=0.75, params={"lang": "suahili"}, timestamp=None, version=None,)
+
+    # first post should be OK - it defines the schema
+    client_to_existing_content.post_point("blabla", p1)
+
+    with pytest.raises(KPYayError):
+        client_to_existing_content.post_point("blabla", p2)


### PR DESCRIPTION
Implements integrity check mentioned in README - all consecutive points must stick to the schema defined by the first point.